### PR TITLE
Support X-Forwarded-For Header for parsing ClientIPs

### DIFF
--- a/config/crd/bases/boot.ironcore.dev_httpbootconfigs.yaml
+++ b/config/crd/bases/boot.ironcore.dev_httpbootconfigs.yaml
@@ -52,10 +52,15 @@ spec:
                   referenced object inside the same namespace.
                 properties:
                   name:
+                    default: ""
                     description: |-
                       Name of the referent.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
                       TODO: Add other useful fields. apiVersion, kind, uid?
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic

--- a/config/crd/bases/boot.ironcore.dev_ipxebootconfigs.yaml
+++ b/config/crd/bases/boot.ironcore.dev_ipxebootconfigs.yaml
@@ -52,10 +52,15 @@ spec:
                   referenced object inside the same namespace.
                 properties:
                   name:
+                    default: ""
                     description: |-
                       Name of the referent.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
                       TODO: Add other useful fields. apiVersion, kind, uid?
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic


### PR DESCRIPTION
# Proposed Changes
Supports X-Forwarded-For Header for parsing ClientIPs. This is useful while working with the ingress controllers such nginx, as standard kubernetes proxy masks the ClientIPs while forwarding the request to the Pods. 

Fixes #
