### PR TITLE
Support /httpboot endpoint

### DIFF
--- a/api/v1alpha1/httpbootconfig_types.go
+++ b/api/v1alpha1/httpbootconfig_types.go
@@ -12,6 +12,8 @@ import (
 type HTTPBootConfigSpec struct {
 	SystemUUID        string                       `json:"systemUUID,omitempty"`
 	IgnitionSecretRef *corev1.LocalObjectReference `json:"ignitionSecretRef,omitempty"`
+	SystemIP          string                       `json:"systemIP,omitempty"`
+	UKIURL            string                       `json:"ukiURL,omitempty"`
 }
 
 // HTTPBootConfigStatus defines the observed state of HTTPBootConfig

--- a/config/crd/bases/boot.ironcore.dev_httpbootconfigs.yaml
+++ b/config/crd/bases/boot.ironcore.dev_httpbootconfigs.yaml
@@ -64,7 +64,11 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              systemIP:
+                type: string
               systemUUID:
+                type: string
+              ukiURL:
                 type: string
             type: object
           status:


### PR DESCRIPTION
# Proposed Changes
Adds support to boot the Machine with HTTPBoot. 
`/httpboot`  is introduced. The UKIURL is returned if the `HTTPBootConfig` related to the ClientIP is found, else the default UKIURL is returned. 

Fixes #
